### PR TITLE
Minor corrections related to the use of `act`

### DIFF
--- a/src/__tests__/useScrollbarSize.test.tsx
+++ b/src/__tests__/useScrollbarSize.test.tsx
@@ -1,5 +1,4 @@
 import React, { FunctionComponent } from 'react';
-// import act from testing library
 import { act, render, screen } from '@testing-library/react';
 import { mockClientDimensions, mockOffsetDimensions } from '../../test/mockDimensions';
 import useScrollbarSize from '../useScrollbarSize';

--- a/src/__tests__/useScrollbarSize.test.tsx
+++ b/src/__tests__/useScrollbarSize.test.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { act } from 'react-dom/test-utils';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { mockClientDimensions, mockOffsetDimensions } from '../../test/mockDimensions';
 import useScrollbarSize from '../useScrollbarSize';
 
@@ -35,9 +34,7 @@ afterAll(() => {
 });
 
 test('should set measurements on initial render', () => {
-	act(() => {
-		render(<ScrollbarSizeExample />);
-	});
+	render(<ScrollbarSizeExample />);
 
 	const height = screen.getByText(/height/i);
 	const width = screen.getByText(/width/i);
@@ -47,9 +44,7 @@ test('should set measurements on initial render', () => {
 });
 
 test('should set measurements on first resize event', () => {
-	act(() => {
-		render(<ScrollbarSizeExample />);
-	});
+	render(<ScrollbarSizeExample />);
 
 	offsetDimensionsMocker.mock(17, 27);
 	act(() => {
@@ -64,9 +59,7 @@ test('should set measurements on first resize event', () => {
 });
 
 test('should not change measurements when scrollbar size is unchanged', () => {
-	act(() => {
-		render(<ScrollbarSizeExample />);
-	});
+	render(<ScrollbarSizeExample />);
 
 	offsetDimensionsMocker.mock(17, 27);
 	act(() => {
@@ -87,9 +80,7 @@ test('should not change measurements when scrollbar size is unchanged', () => {
 });
 
 test('should set height each time scrollbar height changes', () => {
-	act(() => {
-		render(<ScrollbarSizeExample />);
-	});
+	render(<ScrollbarSizeExample />);
 
 	offsetDimensionsMocker.mock(17, 27);
 	act(() => {
@@ -111,9 +102,7 @@ test('should set height each time scrollbar height changes', () => {
 });
 
 test('should set width each time scrollbar width changes', () => {
-	act(() => {
-		render(<ScrollbarSizeExample />);
-	});
+	render(<ScrollbarSizeExample />);
 
 	offsetDimensionsMocker.mock(17, 27);
 	act(() => {
@@ -135,9 +124,7 @@ test('should set width each time scrollbar width changes', () => {
 });
 
 test('should not change sizes if the resize event is not fired', () => {
-	act(() => {
-		render(<ScrollbarSizeExample />);
-	});
+	render(<ScrollbarSizeExample />);
 
 	offsetDimensionsMocker.mock(17, 27);
 

--- a/src/__tests__/useScrollbarSize.test.tsx
+++ b/src/__tests__/useScrollbarSize.test.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react';
+// import act from testing library
 import { act, render, screen } from '@testing-library/react';
 import { mockClientDimensions, mockOffsetDimensions } from '../../test/mockDimensions';
 import useScrollbarSize from '../useScrollbarSize';


### PR DESCRIPTION
## Description :memo:

The purpose of this PR is to address some very minor issues regarding the use of `act`.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- `act` is re-exported from `@testing-library/react` so it can be imported from there.  Testing library recommends importing it this way for 'consistency reasons' (see: https://testing-library.com/docs/react-testing-library/api/#act)
- You don't need to wrap `render` with `act` because it's done for you (see: https://github.com/testing-library/react-testing-library/blob/main/src/pure.js#L59-L65)

## Relevant issues :dart:
<!-- Please indicate relevant open issue -->
N/A

## Type of change :gem:

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor
 
## Example code :scroll:
<!-- Provide some example codes to illustrate how your change works -->
```tsx
	// not this
	act(() => {
		render(<ScrollbarSizeExample />);
	});

	// this
	render(<ScrollbarSizeExample />);
``` 

## How Has This Been Tested? :vertical_traffic_light:

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->
All tests passed

## Checklist :checkered_flag:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] My changes pass lint, prettier, and TS checks
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
