### PR TITLE
Remove transform runtime

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -3,7 +3,6 @@ const commonPresets = [['@babel/preset-react', { runtime: 'automatic' }], '@babe
 module.exports = {
 	ignore: ['**/*.d.ts'],
 	presets: [['@babel/preset-env', { targets: { node: true } }], ...commonPresets], // set base presets
-	plugins: ['@babel/plugin-transform-runtime'],
 	env: {
 		build: {
 			presets: ['@babel/preset-env', ...commonPresets], // override to target .browserslistrc

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@babel/cli": "7.17.10",
     "@babel/core": "7.17.10",
     "@babel/node": "7.17.10",
-    "@babel/plugin-transform-runtime": "7.17.10",
     "@babel/preset-env": "7.17.10",
     "@babel/preset-react": "7.16.7",
     "@babel/preset-typescript": "7.16.7",


### PR DESCRIPTION
Requires a production dependence to use

## Description :memo:

This PR eliminates the addition of `@babel/plugin-transform-runtime` added in #705.  Use of that plugin requires a production dependency to be added which was not added, so the library no longer works properly.  Rather than adding the production dependency, it would be best to keep this library dependency free for now.
