### PR TITLE
feat: add useScrollbarSize named export

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To see a live example, follow these [instructions](/example/README.md).
 
 ```tsx
 import { CSSProperties, FunctionComponent } from 'react';
-import useScrollbarSize from 'react-scrollbar-size';
+import { useScrollbarSize } from 'react-scrollbar-size';
 
 const styles: CSSProperties = {
   margin: '1rem',
@@ -71,7 +71,7 @@ const ScrollbarSizeDemo: FunctionComponent = () => {
 ### JavaScript
 
 ```jsx
-import useScrollbarSize from 'react-scrollbar-size';
+import { useScrollbarSize } from 'react-scrollbar-size';
 
 const styles = {
   margin: '1rem',

--- a/example/ScrollbarSizeDemo.tsx
+++ b/example/ScrollbarSizeDemo.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties, FunctionComponent } from 'react';
-import useScrollbarSize from '../src';
+import { useScrollbarSize } from '../src';
 
 const styles: CSSProperties = {
 	margin: '1rem',

--- a/src/__tests__/useScrollbarSize.test.tsx
+++ b/src/__tests__/useScrollbarSize.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, screen } from '@testing-library/react';
 import type { FunctionComponent } from 'react';
 import { mockClientDimensions, mockOffsetDimensions } from '../../test/mockDimensions';
-import useScrollbarSize from '../useScrollbarSize';
+import { useScrollbarSize } from '../useScrollbarSize';
 
 const ScrollbarSizeExample: FunctionComponent = () => {
 	const { height, width } = useScrollbarSize();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 /* eslint-disable import/no-default-export */
-import useScrollbarSize from './useScrollbarSize';
+import { useScrollbarSize } from './useScrollbarSize';
 
 export type { ScrollbarMeasurements } from './useScrollbarSize';
+
+export { useScrollbarSize };
 
 export default useScrollbarSize;

--- a/src/useScrollbarSize.ts
+++ b/src/useScrollbarSize.ts
@@ -8,7 +8,7 @@ export interface ScrollbarMeasurements {
 	width: number;
 }
 
-const useScrollbarSize = (): ScrollbarMeasurements => {
+export const useScrollbarSize = (): ScrollbarMeasurements => {
 	const [dimensions, setDimensions] = useState({ height: 0, width: 0 });
 	const element = useRef<HTMLDivElement | null>(null);
 
@@ -60,5 +60,3 @@ const useScrollbarSize = (): ScrollbarMeasurements => {
 
 	return dimensions;
 };
-
-export default useScrollbarSize;


### PR DESCRIPTION
## Description :memo:

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds a named export in addition to the current default export. Folks having issues with using this library can then migrate to using named imports, which work better across CJS and ESM.

## Relevant issues :dart:

Workaround for #1140.
<!-- Please indicate relevant open issue -->

## Type of change :gem:

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Example code :scroll:

<!-- Provide some example codes to illustrate how your change works -->

```tsx
import { useScrollbarSize } from 'react-scrollbar-size';
```

## How Has This Been Tested? :vertical_traffic_light:

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

I've tested the output of this in https://github.com/mihkeleidast/react-scrollbar-size-esm-demo by copying the relevant changed dist files to node_modules there, migrating to named imports there, and verifying it then logs the expected useScrollbarSize hook function in both CJS and ESM contexts.

I've also published my own fork with this exact change and verified that moving to named exports works around the original issue.

## Checklist :checkered_flag:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] My changes pass lint, prettier, and TS checks
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
